### PR TITLE
docs: fix links in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,4 +37,4 @@ $ npm install
 $ npm run start
 ```
 
-Once your server is up and running, you can authenticate your vehicle at `http://localhost:3000` in your browser. In our current set up, we are using Smartcar's [test mode](https://smartcar.com), so you can log in with any username and password and you will see information of a simulated vehicle.
+Once your server is up and running, you can authenticate your vehicle at `http://localhost:3000` in your browser. In our current set up, we are using Smartcar's [test mode](https://smartcar.com/docs/guides/testing/), so you can log in with any username and password and you will see information of a simulated vehicle.


### PR DESCRIPTION
```
[I] ➜ markdown-link-check README.md

FILE: README.md
[✓] https://github.com/smartcar/getting-started-node-sdk
[✓] https://github.com/smartcar/getting-started-python-sdk
[✓] https://github.com/smartcar/getting-started-java-sdk
[✓] https://smartcar.com/docs/guides/testing/
```